### PR TITLE
Add WaitForEXE1=wish.exe to GitGUIPortable.ini

### DIFF
--- a/GitPortable/App/AppInfo/Launcher/GitGUIPortable.ini
+++ b/GitPortable/App/AppInfo/Launcher/GitGUIPortable.ini
@@ -1,6 +1,7 @@
 [Launch]
 ProgramExecutable=Git\cmd\git-gui.exe
 WorkingDirectory=%PAL:DataDir%\home
+WaitForEXE1=wish.exe
 DirectoryMoveOK=yes
 
 [Environment]


### PR DESCRIPTION
If the Launcher doesn't wait for wish.exe it deletes GitPortable's contained %TEMP% directory prematurely, causing "bash.exe: warning: could not find /tmp, please create!" to occasionally appear in multiple places, and a few ".tmp" files to appear in the currently opened repository (these are supposed to go in the %TEMP% directory).

This resolves #6, #14 and #17.