### PR TITLE
Add WaitForEXE2=git-bash.exe

### DIFF
--- a/GitPortable/App/AppInfo/Launcher/GitGUIPortable.ini
+++ b/GitPortable/App/AppInfo/Launcher/GitGUIPortable.ini
@@ -2,6 +2,7 @@
 ProgramExecutable=Git\cmd\git-gui.exe
 WorkingDirectory=%PAL:DataDir%\home
 WaitForEXE1=wish.exe
+WaitForEXE2=git-bash.exe
 DirectoryMoveOK=yes
 
 [Environment]


### PR DESCRIPTION
Sorry this didn't get into #18, but I just noticed this today.

This issue basically mirrors #6, #14, #17 & #18, but is caused by a user opening Git Bash from within Git GUI, then closing Git GUI while Git Bash remains open. In this case Git Bash (and Git GUI, if launched from within Git Bash with the `git gui` command) will occasionally print "could not find /tmp" errors, and random `.tmp` files will appear in git's scans of the local repository.