### PR TITLE
Online version

### DIFF
--- a/GitPortable/App/AppInfo/AppInfo.ini
+++ b/GitPortable/App/AppInfo/AppInfo.ini
@@ -1,6 +1,6 @@
 [Format]
 Type=PortableApps.comFormat
-Version=3.4
+Version=3.5
 
 [Details]
 Name=Git Portable
@@ -19,8 +19,8 @@ Freeware=true
 CommercialUse=true
 
 [Version]
-PackageVersion=2.12.90.1
-DisplayVersion=2.13.0 Development Test 1
+PackageVersion=2.20.1.1
+DisplayVersion=2.20.1.1 for Windows
 
 [Control]
 Icons=1

--- a/GitPortable/App/AppInfo/Installer.ini
+++ b/GitPortable/App/AppInfo/Installer.ini
@@ -1,0 +1,12 @@
+[CheckRunning]
+CloseEXE=git-bash.exe
+
+[DownloadFiles]
+AdditionalInstallSize=296500
+
+DownloadURL=https://github.com/git-for-windows/git/releases/download/v2.20.1.windows.1/PortableGit-2.20.1-32-bit.7z.exe
+DownloadName=Git for Windows
+DownloadFilename=PortableGit-2.20.1-32-bit.7z.exe
+DownloadMD5=306e59c3a434535dd28c0138a9560f42
+AdvancedExtract1To=App\Git
+AdvancedExtract1Filter=**

--- a/GitPortable/App/DefaultData/home/.gitconfig
+++ b/GitPortable/App/DefaultData/home/.gitconfig
@@ -1,6 +1,6 @@
 [core]
 	symlinks = false
-	autocrlf = true
+	autocrlf = false
 [color]
 	diff = auto
 	status = auto

--- a/GitPortable/App/Readme.txt
+++ b/GitPortable/App/Readme.txt
@@ -1,3 +1,0 @@
-The files in this directory are necessary for the portable application to
-function. There is normally no need to directly access or alter any of the
-files within these directories.


### PR DESCRIPTION
This updates GitPortable to the latest git release, as well as converts this PA installer to an online installer format.