### PR TITLE
Bump to v2.30.0

### DIFF
--- a/GitPortable/App/AppInfo/AppInfo.ini
+++ b/GitPortable/App/AppInfo/AppInfo.ini
@@ -19,8 +19,8 @@ Freeware=true
 CommercialUse=true
 
 [Version]
-PackageVersion=2.27.0.0
-DisplayVersion=2.27.0.windows.1 Development Build
+PackageVersion=2.30.0.0
+DisplayVersion=2.30.0.windows.1 Development Build
 
 [Control]
 Icons=2

--- a/GitPortable/App/AppInfo/Installer.ini
+++ b/GitPortable/App/AppInfo/Installer.ini
@@ -2,11 +2,11 @@
 CloseEXE=git-bash.exe
 
 [DownloadFiles]
-AdditionalInstallSize=43000
+AdditionalInstallSize=50000
 
-DownloadURL=https://github.com/git-for-windows/git/releases/download/v2.27.0.windows.1/PortableGit-2.27.0-32-bit.7z.exe
+DownloadURL=https://github.com/git-for-windows/git/releases/download/v2.30.0.windows.1/PortableGit-2.30.0-32-bit.7z.exe
 DownloadName=Git for Windows
-DownloadFilename=PortableGit-2.27.0-32-bit.7z.exe
-DownloadMD5=9511e5e4bf759689a07ada50d1b8b38b
+DownloadFilename=PortableGit-2.30.0-32-bit.7z.exe
+DownloadMD5=78acab6e356db9289d33e0d021e26736
 AdvancedExtract1To=App\Git
 AdvancedExtract1Filter=**

--- a/GitPortable/Other/Source/PortableApps.comInstallerCustom.nsh
+++ b/GitPortable/Other/Source/PortableApps.comInstallerCustom.nsh
@@ -1,3 +1,8 @@
+!macro CustomCodePreInstall
+	Delete "$INSTDIR\App\Git\"
+!macroend
+
+
 !macro CustomCodePostInstall
-	;nsExec::Exec `"$INSTDIR\App\Git\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat`
+	nsExec::Exec `"$INSTDIR\App\Git\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat`
 !macroend


### PR DESCRIPTION
Bumps GitPortable to v2.30.0

Fixes initial install post-install.bat run

