### PR TITLE
Bump to v2.55.0.3

### DIFF
--- a/GitPortable/App/AppInfo/AppInfo.ini
+++ b/GitPortable/App/AppInfo/AppInfo.ini
@@ -1,6 +1,6 @@
 [Format]
 Type=PortableApps.comFormat
-Version=3.5
+Version=3.9
 
 [Details]
 Name=Git Portable
@@ -19,8 +19,8 @@ Freeware=true
 CommercialUse=true
 
 [Version]
-PackageVersion=2.40.0.0
-DisplayVersion=2.40.0.windows.0 Development Test 1
+PackageVersion=2.55.0.3
+DisplayVersion=2.55.0(3) Development Test 1
 
 [Control]
 Icons=2

--- a/GitPortable/App/AppInfo/Installer.ini
+++ b/GitPortable/App/AppInfo/Installer.ini
@@ -4,9 +4,9 @@ CloseEXE=git-bash.exe
 [DownloadFiles]
 AdditionalInstallSize=50000
 
-DownloadURL=https://github.com/git-for-windows/git/releases/download/v2.40.0.windows.1/PortableGit-2.40.0-32-bit.7z.exe
+DownloadURL=https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/PortableGit-2.55.0.3-64-bit.7z.exe
 DownloadName=Git for Windows
-DownloadFilename=PortableGit-2.40.0-32-bit.7z.exe
-DownloadMD5=c889fa1e6c8ff3904b338caacb3a33f8
+DownloadFilename=PortableGit-2.55.0.3-64-bit.7z.exe
+DownloadMD5=270a1e08368088da54285cbd390b0737da3edab6
 AdvancedExtract1To=App\Git
 AdvancedExtract1Filter=**

--- a/GitPortable/App/DefaultData/home/.gitconfig
+++ b/GitPortable/App/DefaultData/home/.gitconfig
@@ -11,7 +11,7 @@
 [help]
 	format = html
 [http]
-	sslCAinfo = /ssl/certs/ca-bundle.crt
+	sslCAinfo = /etc/ssl/certs/ca-bundle.crt
 [diff "astextplain"]
 	textconv = astextplain
 [rebase]

--- a/GitPortable/App/DefaultData/home/.gitconfig
+++ b/GitPortable/App/DefaultData/home/.gitconfig
@@ -11,7 +11,7 @@
 [help]
 	format = html
 [http]
-	sslCAinfo = /etc/ssl/certs/ca-bundle.crt
+	sslCAinfo = %(prefix)/etc/ssl/certs/ca-bundle.crt
 [diff "astextplain"]
 	textconv = astextplain
 [rebase]

--- a/GitPortable/App/Readme.txt
+++ b/GitPortable/App/Readme.txt
@@ -1,0 +1,5 @@
+This directory contains files used by the portable app and should generally not be accessed directly by users except in specific instances of using plugins or other documented additions to a given app (see below).
+
+User files, data, or settings should not be stored within the App directory or its subdirectories. Any data stored within the App directory structure will likely be deleted on upgrades.
+
+An exception to this is apps that use plugins. Generally, these directories will be preserved on upgrades. You can confirm which directories are preserved within the installer.ini file inside the App\AppInfo directory. If there are any plugin directories which are not preserved which should be, please let the publisher of this portable app know so they can address the issue.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ If you prefer, you can alternatively install Git Portable manually:
 "GitPortable\App\Git\git-bash.exe" --no-needs-console --hide --no-cd --command=post-install.bat
 ```
 The manual installation instructions can also be used to update the version of Git within an existing Git Portable installation.
+
+### Compiling to `.paf.exe`
+
+If you would like to create the `.paf.exe` file from this source:
+
+1. Copy the `GitPortable` directory from this repository to a location of your choice.
+2. Download and install the [**PortableApps.com Installer**](https://portableapps.com/apps/development/portableapps.com_installer)
+    * Not to be confused with the [**PortableApps.com Platform**](https://portableapps.com/news/2026-07-07--portableapps.com-platform-30.4.2-released), which is the interface that opens when you click the PortableApps tray icon.
+3. From the `PortableApps.com Installer` window, select this source folder, click `Go`, and wait for the `.paf.exe` to be generated. It can now be installed through the **PortableApps.com Platform**
+

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you prefer, you can alternatively install Git Portable manually:
 ```
 The manual installation instructions can also be used to update the version of Git within an existing Git Portable installation.
 
-### Compiling to `.paf.exe`
+### Creating `.paf.exe` from Source
 
 If you would like to create the `.paf.exe` file from this source:
 
@@ -30,4 +30,3 @@ If you would like to create the `.paf.exe` file from this source:
 2. Download and install the [**PortableApps.com Installer**](https://portableapps.com/apps/development/portableapps.com_installer)
     * Not to be confused with the [**PortableApps.com Platform**](https://portableapps.com/news/2026-07-07--portableapps.com-platform-30.4.2-released), which is the interface that opens when you click the PortableApps tray icon.
 3. From the `PortableApps.com Installer` window, select this source folder, click `Go`, and wait for the `.paf.exe` to be generated. It can now be installed through the **PortableApps.com Platform**
-


### PR DESCRIPTION
Bumps the base app to [v2.55.0(3)](https://github.com/git-for-windows/git/releases/tag/v2.55.0.windows.3) and adds basic README instructions on how a user can generate a `.paf.exe` from source.

This is useful to know, so that when there are large time-gaps between version bumps and actual releases, the user still has the option of creating their own `.paf.exe` from this source.